### PR TITLE
Add dotenv loading

### DIFF
--- a/entraDLP2KB4.py
+++ b/entraDLP2KB4.py
@@ -1,6 +1,12 @@
 import requests
 from msal import ConfidentialClientApplication
 import time
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
 # === CONFIGURATION ===
 TENANT_ID = os.environ["TENANT_ID"]
 CLIENT_ID = os.environ["CLIENT_ID"]

--- a/entraPic2Verkada.py
+++ b/entraPic2Verkada.py
@@ -1,6 +1,11 @@
 import requests
 import msal
 import io
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 # === CONFIGURATION ===
 TENANT_ID = os.environ["TENANT_ID"]


### PR DESCRIPTION
## Summary
- enable dotenv support in scripts

## Testing
- `python3 -m py_compile entraDLP2KB4.py entraPic2Verkada.py && echo "py_compile passed"`

------
https://chatgpt.com/codex/tasks/task_e_687d026a7890832b9897475a83c75e2a