### PR TITLE
Fix missing os import

### DIFF
--- a/entraDLP2KB4.py
+++ b/entraDLP2KB4.py
@@ -1,3 +1,4 @@
+import os
 import requests
 from msal import ConfidentialClientApplication
 import time


### PR DESCRIPTION
## Summary
- add missing `os` import for environment config

## Testing
- `python3 -m py_compile entraDLP2KB4.py`

------
https://chatgpt.com/codex/tasks/task_e_687cfff1219c832bb2d6928a3735ab38